### PR TITLE
Resolve crash during gear selection when BootToMenu is disabled

### DIFF
--- a/Riders.Tweakbox/Controllers/CustomGearController/CustomGearCodePatcher.cs
+++ b/Riders.Tweakbox/Controllers/CustomGearController/CustomGearCodePatcher.cs
@@ -1,5 +1,5 @@
 ﻿using Reloaded.Memory.Pointers;
-using Sewer56.SonicRiders.Structures.Gameplay;
+using ExtremeGear = Sewer56.SonicRiders.Structures.Gameplay.ExtremeGear;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
@@ -38,8 +38,8 @@ internal unsafe class CustomGearCodePatcher
     public const int MaxGearCount = 254; // 256th is reserved for "unjoined"
 
     // New pointer targets.
-    private Sewer56.SonicRiders.Structures.Gameplay.ExtremeGear* _newGearsPtr;
-    private Sewer56.SonicRiders.Structures.Gameplay.ExtremeGear[] _newGears;
+    private ExtremeGear* _newGearsPtr;
+    private ExtremeGear[] _newGears;
     private bool[] _unlockedGearModels;
     private byte[] _gearToModelMap;
 

--- a/Riders.Tweakbox/Controllers/CustomGearController/CustomGearCodePatcher.cs
+++ b/Riders.Tweakbox/Controllers/CustomGearController/CustomGearCodePatcher.cs
@@ -212,7 +212,7 @@ internal unsafe class CustomGearCodePatcher
             return;
 
         // Reference to the vanilla location for storing gear unlock state
-        RefFixedArrayPtr<bool> vanillaUnlockedGearModels = new RefFixedArrayPtr<bool>((ulong)0x017BE4E8, (int)Sewer56.SonicRiders.Structures.Enums.ExtremeGearModel.Cannonball + 1);
+        RefFixedArrayPtr<bool> vanillaUnlockedGearModels = new RefFixedArrayPtr<bool>((ulong)0x017BE4E8, (int)ExtremeGearModel.Cannonball + 1);
         for (var x = 0; x < vanillaUnlockedGearModels.Count; x++)
         {
             bool isUnlocked = vanillaUnlockedGearModels[x];
@@ -220,11 +220,11 @@ internal unsafe class CustomGearCodePatcher
         }
 
         // Unlock any remaining custom gears
-        int firstFreeGearModelSlot = (int)Sewer56.SonicRiders.Structures.Enums.ExtremeGearModel.Berserker + 1;
+        int firstFreeGearModelSlot = (int)ExtremeGearModel.Berserker + 1;
         for (var x = firstFreeGearModelSlot; x < State.UnlockedGearModels.Count; x++)
         {
             // If it's defined in the Enum, it's a Vanilla gear, thus managed by the save.
-            if (Enum.IsDefined(typeof(Sewer56.SonicRiders.Structures.Enums.ExtremeGearModel), (byte) x))
+            if (Enum.IsDefined(typeof(ExtremeGearModel), (byte) x))
                 continue;
 
             State.UnlockedGearModels[x] = true;

--- a/Riders.Tweakbox/Controllers/CustomGearController/CustomGearCodePatcher.cs
+++ b/Riders.Tweakbox/Controllers/CustomGearController/CustomGearCodePatcher.cs
@@ -66,7 +66,7 @@ internal unsafe class CustomGearCodePatcher
         fixed (int* ptr = &_gearCountMinusOneArr[0])
             _gearCountMinusOne = ptr;
 
-        fixed (Sewer56.SonicRiders.Structures.Gameplay.ExtremeGear* ptr = &_newGears[0])
+        fixed (ExtremeGear* ptr = &_newGears[0])
             _newGearsPtr = ptr;
 
         // Patch Branches

--- a/Riders.Tweakbox/Controllers/CustomGearController/CustomGearCodePatcher.cs
+++ b/Riders.Tweakbox/Controllers/CustomGearController/CustomGearCodePatcher.cs
@@ -14,6 +14,10 @@ using Sewer56.Hooks.Utilities;
 using Sewer56.SonicRiders;
 using Riders.Tweakbox.Interfaces.Structs.Gears;
 using CustomGearDataInternal = Riders.Tweakbox.Controllers.CustomGearController.Structs.Internal.CustomGearDataInternal;
+using Riders.Tweakbox.Configs;
+using Riders.Tweakbox.Misc;
+using Sewer56.SonicRiders.API;
+using Sewer56.SonicRiders.Structures.Enums;
 
 namespace Riders.Tweakbox.Controllers.CustomGearController;
 
@@ -34,8 +38,8 @@ internal unsafe class CustomGearCodePatcher
     public const int MaxGearCount = 254; // 256th is reserved for "unjoined"
 
     // New pointer targets.
-    private ExtremeGear* _newGearsPtr;
-    private ExtremeGear[] _newGears;
+    private Sewer56.SonicRiders.Structures.Gameplay.ExtremeGear* _newGearsPtr;
+    private Sewer56.SonicRiders.Structures.Gameplay.ExtremeGear[] _newGears;
     private bool[] _unlockedGearModels;
     private byte[] _gearToModelMap;
 
@@ -46,7 +50,7 @@ internal unsafe class CustomGearCodePatcher
 
     // Private members
     private Logger _log = new Logger(LogCategory.CustomGear);
-    
+
     internal CustomGearCodePatcher()
     {
         MakeMaxGearAsmPatches();
@@ -62,13 +66,16 @@ internal unsafe class CustomGearCodePatcher
         fixed (int* ptr = &_gearCountMinusOneArr[0])
             _gearCountMinusOne = ptr;
 
-        fixed (ExtremeGear* ptr = &_newGears[0])
+        fixed (Sewer56.SonicRiders.Structures.Gameplay.ExtremeGear* ptr = &_newGears[0])
             _newGearsPtr = ptr;
 
         // Patch Branches
         UpdateGearCount(OriginalGearCount);
         PatchOpcodes();
         PatchBoundsChecks();
+
+        // Respect save data
+        EventController.OnEnterCharacterSelect += LoadUnlockedGearsFromSave;
     }
 
     /// <summary>
@@ -82,12 +89,36 @@ internal unsafe class CustomGearCodePatcher
         ref var gear = ref data.GearData;
         var gearType = gear.GearType;
         _newGears[GearCount] = gear;
-        _gearToModelMap[GearCount] = (byte)gear.GearModel;
+        _gearToModelMap[GearCount] = (byte)GetFreeGearModelIndex();
 
         var gearIndex = GearCount;
         UpdateGearCount(GearCount + 1);
         data.SetGearIndex(gearIndex);
         PatchMaxGearId(gearIndex);
+    }
+
+    /// <summary>
+    /// Gets the next unused index for an <see cref="ExtremeGearModel"/>.<br></br>
+    /// Intended for assigning arbitrary indices to Custom Extreme Gear for the <see cref="_gearToModelMap"/>, such that they can be unlocked independently of the Extreme Gear used for the physical model.
+    /// </summary>
+    /// <returns></returns>
+    /// <exception cref="InvalidOperationException"></exception>
+    internal int GetFreeGearModelIndex()
+    {
+        bool[] reservedGearModelIndices = GC.AllocateArray<bool>(MaxGearCount);
+        for (int x = 0; x <= GearCount; x++)
+        {
+            int modelIndex = _gearToModelMap[x];
+            reservedGearModelIndices[modelIndex] = true;
+        }
+
+        for (int x = 0; x < reservedGearModelIndices.Length; x++)
+        {
+            if (!reservedGearModelIndices[x])
+                return x;
+        }
+
+        throw new InvalidOperationException("Failed to identify a free gear model index. All possible indices are reserved.");
     }
 
     /// <summary>
@@ -166,6 +197,37 @@ internal unsafe class CustomGearCodePatcher
             }
 
             _log.WriteLine($"[{pointerName}] New Pointer: {(long)apiEndpoint.Pointer:X} (from: {(long)originalData.Pointer:X})");
+        }
+    }
+
+    /// <summary>
+    /// Sets the "Unlocked" state of original game's gears to the currently loaded save file.
+    /// Any custom gears will be automatically unlocked.
+    /// </summary>
+    private void LoadUnlockedGearsFromSave()
+    {
+        // If "Boot to Menu" is enabled, then everything is unlocked anyway, so we don't need to check for saved data.
+        var tweakboxConf = IoC.GetSingleton<TweakboxConfig>();
+        if (tweakboxConf.Data.BootToMenu)
+            return;
+
+        // Reference to the vanilla location for storing gear unlock state
+        RefFixedArrayPtr<bool> vanillaUnlockedGearModels = new RefFixedArrayPtr<bool>((ulong)0x017BE4E8, (int)Sewer56.SonicRiders.Structures.Enums.ExtremeGearModel.Cannonball + 1);
+        for (var x = 0; x < vanillaUnlockedGearModels.Count; x++)
+        {
+            bool isUnlocked = vanillaUnlockedGearModels[x];
+            State.UnlockedGearModels[x] = isUnlocked;
+        }
+
+        // Unlock any remaining custom gears
+        int firstFreeGearModelSlot = (int)Sewer56.SonicRiders.Structures.Enums.ExtremeGearModel.Berserker + 1;
+        for (var x = firstFreeGearModelSlot; x < State.UnlockedGearModels.Count; x++)
+        {
+            // If it's defined in the Enum, it's a Vanilla gear, thus managed by the save.
+            if (Enum.IsDefined(typeof(Sewer56.SonicRiders.Structures.Enums.ExtremeGearModel), (byte) x))
+                continue;
+
+            State.UnlockedGearModels[x] = true;
         }
     }
 


### PR DESCRIPTION
### Description
This change resolves an issue where the game crashes after selecting a character in "Free Race" and `UnlockAllAndBootToMenu` is disabled.

This occurs due to the `CustomGearCodePatcher` setting up the new `_unlockedGearModels` array with `false` for all values.
It seems when a save file is loaded, it fails to update the new array, and only writes to the game's original "unlocked gears" memory space. (Presumably, loading the save writes a block of data to memory, starting from a Pointer that isn't updated by the Patcher?)

This failure to update the new array results in all gears remaining locked, so when the player goes to select a gear for the race, the game crashes as there are no gears to display.

### Implementation
The crux of the implementation is a little crude - Effectively whenever the game loads the Character Select Menu, we check the vanilla game's unlock memory addresses, and clone their state over to the new array. We then manually unlock any custom gears, as there is of course no way to unlock these otherwise.

The custom gears themselves are also granted unique, arbitrary `ExtremeGearModel` values in the `_gearToGearModel` array. This is simply such that custom gears can be unlocked exclusively from the original game's `ExtremeGearModel` they are based on.

### Limitations / Known Issues
- Gear Shop does not work
  - While the shop can still be accessed, it will always display the "No gears are available for sale" message, even if loading the same save file with Riders Tweakbox disabled shows the save should have access to purchasable gears

### Tested Scenarios
I've only tested Single Player functionality, so I'm not sure how these changes would affect Netplay.
Nonetheless, I've tested with both a complete (i.e, all gears unlocked) save file and an incomplete one, alongside zero, one, and two custom gears in both scenarios, and had no issues in Free Race.

Default-only gamemodes such as Survival Mode also work as expected.
